### PR TITLE
Feature unapplied migrations only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,7 @@ Usage
 ``--database DATABASE``                            Specify the database for which to generate the SQL. Defaults to *default*.
 ``--cache-path PATH``                              specify a directory that should be used to store cache-files in.
 ``--no-cache``                                     Don't use a cache.
+``--include-migration-file MIGRATIONS_FILE``       only in file created: python manage.py showmigrations | grep '\[ \]\|^[a-z]' | grep '[  ]' -B 1 > unapplied_migrations.log
 ================================================== ===========================================================================================================================
 
 Examples

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -244,15 +244,15 @@ class MigrationLinter(object):
                     migration_name in self.parsed_unapplied_migrations[app_name])
             return should_ignore
         else:
-        return (
-            (self.include_apps and app_name not in self.include_apps)
-            or (self.exclude_apps and app_name in self.exclude_apps)
-            or (
-                self.ignore_name_contains
-                and self.ignore_name_contains in migration_name
+            return (
+                (self.include_apps and app_name not in self.include_apps)
+                or (self.exclude_apps and app_name in self.exclude_apps)
+                or (
+                    self.ignore_name_contains
+                    and self.ignore_name_contains in migration_name
+                )
+                or (migration_name in self.ignore_name)
             )
-            or (migration_name in self.ignore_name)
-        )
 
 
 def _main():

--- a/django_migration_linter/migration_linter.py
+++ b/django_migration_linter/migration_linter.py
@@ -180,7 +180,7 @@ class MigrationLinter(object):
         """
         if self.zappa_stage:
             sqlmigrate_command = (
-                "zappa manage {0} sqlmigrate {1} '{2}' --database {3}"
+                "zappa manage {0} \"sqlmigrate {1} {2} --database {3}\""
             ).format(
                 self.zappa_stage, app_name, migration_name, self.database
             )
@@ -348,7 +348,7 @@ def _main():
              "which should be generated with "
              "\'python manage.py showmigrations | grep '\[ \]\|^[a-z]' | grep '[  ]' -B 1 > unapplied_migrations.log'"
     )
-    incl_excl_group.add_argument(
+    parser.add_argument(
         "--zappa-stage",
         type=str,
         help="use zappa manage to get_sql from specified stage"

--- a/django_migration_linter/utils.py
+++ b/django_migration_linter/utils.py
@@ -81,3 +81,27 @@ def compose_migration_path(django_folder, app_name, migration):
 
 def clean_bytes_to_str(byte_input):
     return byte_input.decode("utf-8").strip()
+
+
+def parse_unapplied_migrations(filename):
+    target = {}
+    app_name = None
+    migrations = []
+
+    with open(filename, 'r') as migration_file:
+        for line in [line.strip() for line in migration_file.readlines()]:
+            app_name_match = re.match(r"^([a-zA-Z0-9_\.]*)$", line)
+            migration_name_match = re.match(r"^\s*\[\s\]\s*([a-zA-Z0-9_\.]*)$", line)
+
+            if app_name_match and len(app_name_match.groups()) == 1:
+                if app_name and len(migrations) > 0:
+                    target[app_name] = migrations
+                    migrations = []
+
+                app_name = app_name_match.groups()[0]
+            elif migration_name_match and len(migration_name_match.groups()) == 1:
+                migrations.append(migration_name_match.groups()[0])
+
+    if app_name and len(migrations) > 0:
+        target[app_name] = migrations
+    return target

--- a/django_migration_linter/utils.py
+++ b/django_migration_linter/utils.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import os
 import sys
+import re
 
 from .constants import MIGRATION_FOLDER_NAME
 


### PR DESCRIPTION
`django-migration-linter` looks like a reasonable solution to ensure we have backward compatibility in our db migrations, so that our CI deploying `beta` won't break `prod`.

@littlebtc: Let's follow the recommendations from https://medium.com/3yourmind/keeping-django-database-migrations-backward-compatible-727820260dbb from now on to insure backward compatibility. 

This linter though doesn't have a feature that would apply it to pending migrations.
This pull requests is a temporary solution to this:

```
python manage.py showmigrations | grep '\[ \]\|^[a-z]' | grep '[  ]' -B 1 > unapplied_migrations.log
django-migration-linter ./ --include-migration-file unapplied_migrations.log --no-cache
```